### PR TITLE
Update constraint layout to 1.1.3

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
     implementation "com.android.support:recyclerview-v7:$recyclerview_version"
 
     // Retrofit


### PR DESCRIPTION
Update to constraint layout 1.1.3.

The app still works and the [changelog](https://androidstudio.googleblog.com/2018/08/constraintlayout-113.html) doesnt mention any breaking changes.