### PR TITLE
Gradle Upgrade

### DIFF
--- a/Contributors.MD
+++ b/Contributors.MD
@@ -1,0 +1,2 @@
+## Name: Naledi Madlopha
+## GitHub: [NalediMadlopha](https://github.com/NalediMadlopha)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
     // Support Libraries
-    implementation "com.android.support:design:$android_support_version"
+    implementation "com.android.support:design:$support_version"
     implementation "com.android.support:appcompat-v7:$support_version"
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,7 @@ android {
     }
     buildTypes {
         debug {
-            buildConfigField 'String', "ApiKey", System.getenv("Guardian_ApiKey")
+            buildConfigField 'String', "ApiKey", Guardian_ApiKey
         }
         release {
             minifyEnabled false

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
     defaultConfig {
         applicationId "com.android.nikhil.worldnow"
         minSdkVersion 19
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -27,9 +27,9 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.2'
-    implementation "com.android.support:recyclerview-v7:$recyclerview_version"
+    implementation "com.android.support:design:$android_support_version"
+    implementation "com.android.support:appcompat-v7:$android_support_version"
+    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
 
     // Retrofit
     implementation "com.squareup.retrofit2:retrofit:$retrofit_version"
@@ -56,6 +56,10 @@ dependencies {
     // Logging Interceptor
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttp_interceptor_version"
 
+    // Glide
+    implementation 'com.github.bumptech.glide:glide:4.6.1'
+
+    // Testing
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,7 @@ android {
     }
     buildTypes {
         debug {
-            buildConfigField 'String', "ApiKey", Guardian_ApiKey
+            buildConfigField 'String', "ApiKey", System.getenv("Guardian_ApiKey")
         }
         release {
             minifyEnabled false

--- a/build.gradle
+++ b/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.2.50'
+    ext.kotlin_version = '1.2.71'
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.android.tools.build:gradle:3.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -23,7 +23,7 @@ allprojects {
 }
 
 ext {
-    recyclerview_version = "27.1.1"
+    android_support_version = "28.0.0"
     retrofit_version = "2.4.0"
     gson_version = "2.8.5"
     gson_convertor_version = "2.4.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 19 18:01:17 IST 2018
+#Tue Oct 02 23:52:03 SAST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
- Add myself as a contributor to the project
- Bump-up Gradle distributions version
- Gradle Update
     * Bump-up the compile and target SDK versions
     * Remove the recycler view's explicit dependency implementation, the
        recycler view is included in the Android Support AppCompat
     * Add the Android Support Design library
     * Implement Glide as a dependency, Glide will be used to render and
       cache images from the API
- Gradle Tools Upgrade
     * Bump-up the Kotlin version
     * Bump-up the Gradle build tools