### PR TITLE
Change the way of loading Guardian_ApiKey

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ android:
     - build-tools-28.0.3
     - android-28
 before_install:
+  - sed -i "\$a Guardian_ApiKey=$Guardian_ApiKey" ./gradle.properties
   - chmod +x gradlew
   - yes | sdkmanager "platforms;android-28"
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ android:
     - build-tools-28.0.3
     - android-28
 before_install:
-  - sed -i "\$a Guardian_ApiKey=$Guardian_ApiKey" ./gradle.properties
+  - sed -i "\$a Guardian_ApiKey=\"Test_Key\"" ./gradle.properties
   - chmod +x gradlew
   - yes | sdkmanager "platforms;android-28"
 before_cache:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,7 @@ android {
     }
     buildTypes {
         debug {
-            buildConfigField 'String', "ApiKey", System.getenv("Guardian_ApiKey")
+            buildConfigField 'String', "ApiKey", Guardian_ApiKey
         }
         release {
             minifyEnabled false


### PR DESCRIPTION
This script adds ApiKey directly to
gradle.properties, so there is no need to call System.getenv() in
build.gradle.

